### PR TITLE
Fixed io#read when invoked with nil argument

### DIFF
--- a/lib/packable/extensions/io.rb
+++ b/lib/packable/extensions/io.rb
@@ -63,7 +63,7 @@ module Packable
       end
     
       def read_with_packing(*arg)
-        return read_without_packing(*arg) if (arg.length == 0) || (arg.first.is_a?(Numeric) && (arg.length == 1))
+        return read_without_packing(*arg) if (arg.length == 0) || arg.first.nil? || (arg.first.is_a?(Numeric) && (arg.length == 1))
         values = Packable::Packers.to_class_option_list(*arg).map do |klass, options, original|
           if options[:read_packed]
             options[:read_packed].call(self)

--- a/test/packing_test.rb
+++ b/test/packing_test.rb
@@ -76,6 +76,12 @@ class TestingPack < Test::Unit::TestCase
     assert_equal "!", io.read
   end
 
+  def test_io_read_nil
+    # library was failing to call read_without_packing when invoked with nil.
+    io = StringIO.new("should read(nil)")
+    assert_equal "should read(nil)", io.read(nil)
+  end
+
   should "do basic type checking" do
     assert_raise(TypeError) {"".unpack(42, :short)}
   end


### PR DESCRIPTION
This PR fixes the case where IO#read is invoked with nil argument (eg. `myio.read(nil)`) which should use the original implementation instead of the packable one.

To make best use of the non-regression test, please merge #5 first.