### PR TITLE
Fixed io#read when invoked with fixnum and outbuf arguments.

### DIFF
--- a/lib/packable/extensions/io.rb
+++ b/lib/packable/extensions/io.rb
@@ -63,7 +63,7 @@ module Packable
       end
     
       def read_with_packing(*arg)
-        return read_without_packing(*arg) if (arg.length == 0) || arg.first.nil? || (arg.first.is_a?(Numeric) && (arg.length == 1))
+        return read_without_packing(*arg) if arg.length == 0 || arg.first.nil? || arg.first.is_a?(Numeric)
         values = Packable::Packers.to_class_option_list(*arg).map do |klass, options, original|
           if options[:read_packed]
             options[:read_packed].call(self)

--- a/test/packing_test.rb
+++ b/test/packing_test.rb
@@ -82,6 +82,13 @@ class TestingPack < Minitest::Test
     assert_equal "should read(nil)", io.read(nil)
   end
 
+  def test_io_read_to_outbuf
+    # library was failing to call read_without_packing when invoked with fixnum and output buffer.
+    io = StringIO.new("should read(fixnum, buf)")
+    io.read(11, outbuf='')
+    assert_equal "should read", outbuf
+  end
+
   should "do basic type checking" do
     assert_raises(TypeError) {"".unpack(42, :short)}
   end


### PR DESCRIPTION
In the same spirit as #6, this PR allows to invoke the original implementation of `IO#read` when invoked with fixnum and outbuf arguments.

Without this PR, using `IO#read` with an output buffer parameter, which is totally [legit](http://ruby-doc.org/core-2.2.0/IO.html#method-i-read), fails in obscure manner (especially if we are not using packable but inherit it from another gem that we depend on):

```ruby
  def test_io_read_to_outbuf
    io = StringIO.new("should read(fixnum, buf)")
    io.read(11, outbuf='')
    assert_equal "should read", outbuf
  end
```

Results in the following error:

```sh
  1) Error:
TestingPack#test_io_read_to_outbuf:
TypeError: Expected a class or symbol: 11
    /home/julien/RubymineProjects/packable/lib/packable/packers.rb:56:in `to_class_option_list'
    /home/julien/RubymineProjects/packable/lib/packable/extensions/io.rb:67:in `read_with_packing'
    /home/julien/RubymineProjects/packable/test/packing_test.rb:88:in `test_io_read_to_outbuf'
```