### PR TITLE
Cherry-picking from backports

### DIFF
--- a/lib/packable.rb
+++ b/lib/packable.rb
@@ -1,5 +1,6 @@
 require "packable/version"
-require 'backports'
+require 'backports/tools/alias_method_chain'
+require 'backports/rails/module'
 require_relative 'packable/packers'
 require_relative 'packable/mixin'
 [Object, Array, String, Integer, Float, IO, Proc].each do |klass|


### PR DESCRIPTION
It turned out that `require 'backports'` (entire library) is not a good thing, all in all:
```ruby
require 'matrix'
Matrix.zero(2).column_count # => 2
require 'backports'
Matrix.zero(2).column_count # => nil
```
As `backports` seem to be abandoned by now, the proposed fix just cherry-picks to `packable` the part of backports that is relevant.