### PR TITLE
Attempt to fix Ruby 3.0 ArgumentError

### DIFF
--- a/lib/packable/extensions/io.rb
+++ b/lib/packable/extensions/io.rb
@@ -73,7 +73,7 @@ module Packable
 
       def each_with_packing(*options, &block)
         return each_without_packing(*options, &block) if options.empty? || (Integer === options.first) || (String === options.first) || !seekable?
-        return Enumerator.new(self, :each_with_packing, *options) unless block_given?
+        return self.to_enum(__method__, *options) unless block_given?
         yield read(*options) until eof?
       end
 


### PR DESCRIPTION
This is an attempt to fix the following Error with Ruby 3.0 (closes #15)

  1) Error:
PackableDocTest#test_doc:
ArgumentError: tried to create Proc object without a block
    /<<PKGBUILDDIR>>/debian/ruby-packable/usr/share/rubygems-integration/all/gems/packable-1.3.14/lib/packable/extensions/io.rb:76:in `initialize'
    /<<PKGBUILDDIR>>/debian/ruby-packable/usr/share/rubygems-integration/all/gems/packable-1.3.14/lib/packable/extensions/io.rb:76:in `new'
    /<<PKGBUILDDIR>>/debian/ruby-packable/usr/share/rubygems-integration/all/gems/packable-1.3.14/lib/packable/extensions/io.rb:76:in `each_with_packing'
    /<<PKGBUILDDIR>>/test/packing_doc_test.rb:22:in `test_doc'