### PR TITLE
Remove `alias_method_chain`

### DIFF
--- a/lib/packable.rb
+++ b/lib/packable.rb
@@ -1,5 +1,4 @@
 require "packable/version"
-require 'backports/tools/alias_method_chain'
 require 'backports/rails/module'
 require_relative 'packable/packers'
 require_relative 'packable/mixin'

--- a/lib/packable/extensions/array.rb
+++ b/lib/packable/extensions/array.rb
@@ -5,7 +5,8 @@ module Packable
     module Array #:nodoc:
       def self.included(base)
         base.class_eval do
-          alias_method_chain :pack, :long_form
+          alias_method :pack_without_long_form, :pack
+          alias_method :pack, :pack_with_long_form
           include Packable
           extend ClassMethods
         end

--- a/lib/packable/extensions/io.rb
+++ b/lib/packable/extensions/io.rb
@@ -5,9 +5,12 @@ module Packable
   module Extensions #:nodoc:
     module IO
       def self.included(base) #:nodoc:
-        base.alias_method_chain :read, :packing
-        base.alias_method_chain :write, :packing
-        base.alias_method_chain :each, :packing
+        base.__send__(:alias_method, :read_without_packing, :read)
+        base.__send__(:alias_method, :read, :read_with_packing)
+        base.__send__(:alias_method, :write_without_packing, :write)
+        base.__send__(:alias_method, :write, :write_with_packing)
+        base.__send__(:alias_method, :each_without_packing, :each)
+        base.__send__(:alias_method, :each, :each_with_packing)
       end
 
       # Methods supported by seekable streams.

--- a/lib/packable/extensions/string.rb
+++ b/lib/packable/extensions/string.rb
@@ -8,7 +8,8 @@ module Packable
         base.class_eval do
           include Packable
           extend ClassMethods
-          alias_method_chain :unpack, :long_form
+          alias_method :unpack_without_long_form, :unpack
+          alias_method :unpack, :unpack_with_long_form
           packers.set :merge_all, :fill => " "
         end
       end


### PR DESCRIPTION
I have confirmed that using packable 1.3.15 in Rails 5.0 will result in some deprecation warnings. It appears that the warnings will appear regardless of whether backports gem are used or not. So, why not stop using `alias_method_chain`?