### PR TITLE
Remove unnecessary `require 'backports/rails/module'`

### DIFF
--- a/lib/packable.rb
+++ b/lib/packable.rb
@@ -1,5 +1,4 @@
 require "packable/version"
-require 'backports/rails/module'
 require_relative 'packable/packers'
 require_relative 'packable/mixin'
 [Object, Array, String, Integer, Float, IO, Proc].each do |klass|


### PR DESCRIPTION
At the previous pull request, I forgot to remove unnecessary file loading, so I'll do so in this pull request.

- https://github.com/marcandre/packable/pull/18

The backports/rails/module.rb is only for the use of `alias_method_chain`, so it should not be needed now that we no longer use it.

- https://github.com/marcandre/backports/blob/v3.24.0/lib/backports/rails/module.rb

This change also eliminates the unncessary deprecation warning on loading packable gem.

Before:

```
$ bundle exec ruby -I lib -r packable -e ""
Rails backports are deprecated.
```

After:

```
$ bundle exec ruby -I lib -r packable -e ""
```