### PR TITLE
Remove backports dependency

### DIFF
--- a/packable.gemspec
+++ b/packable.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'backports'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'shoulda'
   gem.add_development_dependency 'mocha'


### PR DESCRIPTION
It's no longer required since https://github.com/marcandre/packable/pull/19 as far as I can tell. Though it might mean that we need to bump the required Ruby version?